### PR TITLE
Adding responsive image shortcode

### DIFF
--- a/DirigoEdge/App_Start/RouteConfig.cs
+++ b/DirigoEdge/App_Start/RouteConfig.cs
@@ -186,14 +186,26 @@ namespace DirigoEdge
             routes.MapRoute(
                 name: "DynamicImagesSmall",
                 url: "images/small/{*path}",
-                defaults: new { controller = "Images", action = "RenderWithResize", width = 480, height = 320, directory = "small", }
+                defaults: new { controller = "Images", action = "RenderWithResize", width = 480, height = 0, directory = "small", }
             );
 
             routes.MapRoute(
-                name: "DynamicImagesMed",
+                name: "DynamicImagesMedium",
                 url: "images/medium/{*path}",
-                defaults: new { controller = "Images", action = "RenderWithResize", width = 1024, height = 800, directory = "medium" }
-            );           
+                defaults: new { controller = "Images", action = "RenderWithResize", width = 1024, height = 0, directory = "medium" }
+            );
+
+            routes.MapRoute(
+                name: "DynamicImagesLarge",
+                url: "images/large/{*path}",
+                defaults: new { controller = "Images", action = "RenderWithResize", width = 1920, height = 0, directory = "large" }
+            );
+
+            routes.MapRoute(
+                name: "DynamicImagesExtreme",
+                url: "images/extreme/{*path}",
+                defaults: new { controller = "Images", action = "RenderWithResize", width = 2560, height = 0, directory = "extreme" }
+            );   
 
             #endregion
 

--- a/DirigoEdge/DirigoEdgeWeb.csproj
+++ b/DirigoEdge/DirigoEdgeWeb.csproj
@@ -62,9 +62,9 @@
     <Reference Include="AutoMapper.Net4">
       <HintPath>..\packages\AutoMapper.3.3.1\lib\net40\AutoMapper.Net4.dll</HintPath>
     </Reference>
-    <Reference Include="DirigoEdgeCore, Version=1.4.11.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="DirigoEdgeCore, Version=1.4.12.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\DirigoEdgeCore.1.4.11.0\lib\net45\DirigoEdgeCore.dll</HintPath>
+      <HintPath>..\packages\DirigoEdgeCore.1.4.12.0\lib\net45\DirigoEdgeCore.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -439,6 +439,7 @@
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
     <Compile Include="Migrations\Configuration.cs" />
+    <Compile Include="Models\Shortcodes\ResponsiveImageShortcode.cs" />
     <Compile Include="Models\ViewModels\BlogArchiveViewModel.cs" />
     <Compile Include="Models\ViewModels\BlogAuthorViewModel.cs" />
     <Compile Include="Models\ViewModels\BlogCategoriesViewModel.cs" />
@@ -1272,6 +1273,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Areas\Admin\Views\Shared\Partials\ModuleEditHeaderPartial.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Shared\Partials\_ResponsiveImagePartial.cshtml" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/DirigoEdge/Global.asax.cs
+++ b/DirigoEdge/Global.asax.cs
@@ -2,10 +2,10 @@
 using System.Web.Mvc;
 using System.Web.Routing;
 using DirigoEdge.Data.Context;
+using DirigoEdge.Models.Shortcodes;
 using DirigoEdgeCore.Data.Entities;
 using DirigoEdgeCore.PluginFramework;
 using DirigoEdgeCore.Utils;
-using DirigoEdgeCore.Utils.Extensions;
 using DirigoEdgeCore.Utils.Logging;
 
 namespace DirigoEdge
@@ -37,6 +37,9 @@ namespace DirigoEdge
 
             // Add the new View Engine for our plugins to use
             ViewEngines.Engines.Add(new PluginRazorViewEngine());
+
+            // Register new dynamic modules/shortcodes
+            DynamicModules.Instance.AddDynamicModule("responsive_image", new ResponsiveImageShortcode());
         }
 
         // May need to store host in distributed or multi-tenant applications

--- a/DirigoEdge/Models/Shortcodes/ResponsiveImageShortcode.cs
+++ b/DirigoEdge/Models/Shortcodes/ResponsiveImageShortcode.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using DirigoEdgeCore.Utils;
+
+namespace DirigoEdge.Models.Shortcodes
+{
+    public class ResponsiveImageShortcode : IShortcode
+    {
+        public string ClassName = "responsive-image";
+        public string ImagePath = "";
+        public string AltText = "";
+        public int Width = 0;
+        public int Height = 0;
+
+        public string GetDisplayName()
+        {
+            return "Responsive Image";
+        }
+
+        public string GetCSSClass()
+        {
+            return ClassName;
+        }
+
+        public string GetHtml(Dictionary<string, string> parameters)
+        {
+            ClassName = parameters != null && parameters.ContainsKey("class") ? parameters["class"] : "responsive-image";
+
+            if (parameters != null && parameters.ContainsKey("src") && !String.IsNullOrEmpty(parameters["src"]))
+            {
+                ImagePath = parameters["src"];
+            }
+
+            if (parameters != null && parameters.ContainsKey("alt") && !String.IsNullOrEmpty(parameters["alt"]))
+            {
+                AltText = parameters["alt"];
+            }
+
+            if (parameters != null && parameters.ContainsKey("width") && !String.IsNullOrEmpty(parameters["width"]))
+            {
+                Width = Convert.ToInt16(parameters["width"]);
+            }
+
+            if (parameters != null && parameters.ContainsKey("height") && !String.IsNullOrEmpty(parameters["height"]))
+            {
+                Height = Convert.ToInt16(parameters["height"]);
+            }
+
+            return DynamicModules.GetViewHtml("Partials/_ResponsiveImagePartial", this);
+        }
+
+        public object GetViewModel()
+        {
+            return null;
+        }
+
+        public string GetPartialView()
+        {
+            return null;
+        }
+
+        public bool PageBuilderEnabled()
+        {
+            return false;
+        }
+    }
+}

--- a/DirigoEdge/Views/Shared/Partials/ResponsiveBackgroundImage.cshtml
+++ b/DirigoEdge/Views/Shared/Partials/ResponsiveBackgroundImage.cshtml
@@ -1,7 +1,12 @@
 ﻿@model DirigoEdgeCore.Models.ImageResizing.ResponsiveBackgroundImageViewModel
 
 <style class="@Model.ClassName">
-    @foreach (var image in Model.Images)
+    @if (Model.Width != 0 && Model.AspectRatio != 0)
+    {
+        @Html.Raw("#" + Model.RandomId + " { width: " + Model.Width + "px; max-width: 100%; background-size: cover; background-position: center; background-repeat: no-repeat }\n");
+        @Html.Raw("#" + Model.RandomId + ":after { content: ''; display: block; padding-bottom: " + (Model.AspectRatio * 100) + "%; }\n");
+    }
+     @foreach (var image in Model.Images)
     {
         if (image.Width.GetValueOrDefault() == 0)
         {
@@ -13,8 +18,8 @@
 
             @Html.Raw(mediaQuery)
         }
-        
+
     }
 </style>
 
-<div id="@Model.RandomId" class="@Model.ClassName" data-bgimage="@Model.Images[0].Filepath"></div>
+<div id="@Model.RandomId" class="@Model.ClassName" data-bgimage="@Model.Images[0].Filepath" title="@Model.AltText"></div>

--- a/DirigoEdge/Views/Shared/Partials/_ResponsiveImagePartial.cshtml
+++ b/DirigoEdge/Views/Shared/Partials/_ResponsiveImagePartial.cshtml
@@ -1,0 +1,4 @@
+﻿@using DirigoEdgeCore.Utils.Extensions
+@model DirigoEdge.Models.Shortcodes.ResponsiveImageShortcode
+
+@Html.RenderBackgroundImage(Model.ClassName, Model.ImagePath, Model.AltText, Model.Width, Model.Height)

--- a/DirigoEdge/packages.config
+++ b/DirigoEdge/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="AutoMapper" version="3.3.1" targetFramework="net45" />
   <package id="CodeFirstMembershipProviderSharp" version="1.0.0" targetFramework="net45" />
-  <package id="DirigoEdgeCore" version="1.4.11.0" targetFramework="net45" />
+  <package id="DirigoEdgeCore" version="1.4.12.0" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.2" targetFramework="net45" />
   <package id="ImageResizer" version="3.4.3" targetFramework="net45" />
   <package id="ImageResizer.Plugins.PrettyGifs" version="3.4.3" targetFramework="net45" />


### PR DESCRIPTION
Relies on https://github.com/dirigodev/DirigoEdgeCore/pull/9

* Add more dynamic image routes
* Add new `responsive_image` shortcode

Responsive image shortcode usage:
```
[responsive_image src="/uploaded/asdf/rocket-ship.jpg" class="right" width="1605" height="1075" alt="A picture of a rocket ship"]
```

`width` and `height` are the dimensions of the original image.