### PR TITLE
Responsive image fix

### DIFF
--- a/DirigoEdge/CustomUtils/ResponsiveImageUtils.cs
+++ b/DirigoEdge/CustomUtils/ResponsiveImageUtils.cs
@@ -51,12 +51,17 @@ namespace DirigoEdge.CustomUtils
 
         public class ResponsiveImageObject
         {
+            private string _sizes = ResponsiveImageSizes;
             public string ClassName { get; set; }
-            public string Sizes { get; set; }
             public string ImagePath { get; set; }
             public string AltText { get; set; }
             public int Width { get; set; }
             public int Height { get; set; }
+            public string Sizes
+            {
+                get { return _sizes; }
+                set { _sizes = value; }
+            }
         }
     }
 }

--- a/DirigoEdge/Views/Shared/Partials/_ResponsiveImagePartial.cshtml
+++ b/DirigoEdge/Views/Shared/Partials/_ResponsiveImagePartial.cshtml
@@ -5,7 +5,7 @@
     var sources = new List<string>();
 }
 
-@foreach (var route in ResponsiveImageUtils.ResponsiveImageRoutes)
+@foreach (var route in ResponsiveImageUtils.ResponsiveImageRoutes.Where(x => x.Width < Model.Width))
 {
     sources.Add(String.Format("/{0}{1} {2}w", route.Path, Model.ImagePath.Replace(" ", "%20"), route.Width));
 }
@@ -15,8 +15,16 @@
     sources.Add(String.Format("{0} {1}w", Model.ImagePath.Replace(" ", "%20"), Model.Width));
 }
 
-<img sizes="@Model.Sizes"
-     srcset="@String.Join(", ", sources)"
-     class="@Model.ClassName"
-     alt="@Model.AltText"
-     style="width: @(Model.Width + "px")">
+@* If there's only 1 source, not point in using srcset *@
+@if (sources.Count > 1)
+{
+    <img sizes="@Model.Sizes"
+         srcset="@String.Join(", ", sources)"
+         class="@Model.ClassName"
+         alt="@Model.AltText"
+         style="width: @(Model.Width + "px")">
+}
+else
+{
+    <img src="@Model.ImagePath" class="@Model.ClassName" alt="@Model.AltText"/>
+}

--- a/DirigoEdge/Views/Shared/Partials/_ResponsiveImagePartial.cshtml
+++ b/DirigoEdge/Views/Shared/Partials/_ResponsiveImagePartial.cshtml
@@ -18,4 +18,5 @@
 <img sizes="@Model.Sizes"
      srcset="@String.Join(", ", sources)"
      class="@Model.ClassName"
-     alt="@Model.AltText">
+     alt="@Model.AltText"
+     style="width: @(Model.Width + "px")">


### PR DESCRIPTION
There was some whacky resizing stuff going on with the responsive image code, where images would appear really tiny. This fixes.

Also, no longer generating superfluous srcset sources.