### PR TITLE
Schemas using modules will list modules excluding drafts. Fixes #197.

### DIFF
--- a/DirigoEdge/Areas/Admin/Controllers/SchemasController.cs
+++ b/DirigoEdge/Areas/Admin/Controllers/SchemasController.cs
@@ -248,6 +248,13 @@ namespace DirigoEdge.Areas.Admin.Controllers
             return result;
         }
 
+        /// <summary>
+        /// Used when adding module field to schema 
+        /// to list modules under a specific schema id, 
+        /// excluding drafts
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>JSON List of module names ordered A-Z</returns>
         [HttpGet]
         [PermissionsFilter(Permissions = "Can Edit Modules")]
         [AcceptVerbs(HttpVerbs.Get)]
@@ -255,7 +262,11 @@ namespace DirigoEdge.Areas.Admin.Controllers
         {
             var result = new JsonResult { JsonRequestBehavior = JsonRequestBehavior.AllowGet };
 
-            List<string> moduleNames = Context.ContentModules.Where(x => x.SchemaId == id).Select(x => x.ModuleName).ToList();
+            List<string> moduleNames = Context.ContentModules
+                .Where(x => x.SchemaId == id && x.ParentContentModuleId == null)
+                .Select(x => x.ModuleName)
+                .OrderBy(x => x)
+                .ToList();
 
             result.Data = new { moduleNames };
 

--- a/SmokeTests/SmokeTests.csproj
+++ b/SmokeTests/SmokeTests.csproj
@@ -16,6 +16,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -91,6 +93,13 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Create a schema with a module field. Apply another schema to a few modules. When you create a module and assign the new schema to it, the module dropdown should contain only published modules and in alphabetical order.