### PR TITLE
Refactor PageDetails retreival, 404 handling

### DIFF
--- a/DirigoEdge/Areas/Admin/Controllers/PagesController.cs
+++ b/DirigoEdge/Areas/Admin/Controllers/PagesController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.IO;
 using System.Linq;
 using System.Web.Mvc;
@@ -174,7 +175,7 @@ namespace DirigoEdge.Areas.Admin.Controllers
         [PermissionsFilter(Permissions = "Can Edit Pages")]
         public ActionResult PreviewContent(int id)
         {
-            var model = new ContentViewViewModel { ThePage = ContentLoader.GetDetailById(id) };
+            var model = new ContentViewViewModel { ThePage = ContentLoader.GetDetailsById(id) };
             model.TheTemplate = ContentLoader.GetContentTemplate(model.ThePage.Template);
             model.PageData = ContentUtils.GetFormattedPageContentAndScripts(model.ThePage.HTMLContent);
 
@@ -184,7 +185,7 @@ namespace DirigoEdge.Areas.Admin.Controllers
                 return View(model.TheTemplate.ViewLocation, model);
             }
 
-            model = new ContentViewViewModel { ThePage = ContentLoader.GetDetailsByTitle("404") };
+            model = new ContentViewViewModel { ThePage = ContentLoader.GetDetailsById(Convert.ToInt16(ConfigurationManager.AppSettings["404ContentPageId"])) };
 
             model.TheTemplate = ContentLoader.GetContentTemplate(model.ThePage.Template);
             model.PageData = ContentUtils.GetFormattedPageContentAndScripts(model.ThePage.HTMLContent);

--- a/DirigoEdge/Business/EditContentHelper.cs
+++ b/DirigoEdge/Business/EditContentHelper.cs
@@ -31,7 +31,7 @@ namespace DirigoEdge.Business
             model.EditURL = "editcontent";
 
             var contentLoader = new ContentLoader();
-            model.ContentPage.Details = contentLoader.GetDetailById(id);
+            model.ContentPage.Details = contentLoader.GetDetailsById(id);
 
             var ext = _context.ContentPageExtensions.FirstOrDefault(ex => ex.ContentPageId == id);
             Mapper.Map(ext, model.ContentPage);

--- a/DirigoEdge/Controllers/AccountController.cs
+++ b/DirigoEdge/Controllers/AccountController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Configuration;
 using System.Linq;
 using System.Web.Mvc;
 using System.Web.Security;
@@ -219,14 +220,14 @@ namespace DirigoEdge.Controllers
                 return View(model.TheTemplate.ViewLocation, model);
             }
 
-            model = new ContentViewViewModel { ThePage = ContentLoader.GetDetailsByTitle("404") };
+            model = new ContentViewViewModel { ThePage = ContentLoader.GetDetailsById(Convert.ToInt16(ConfigurationManager.AppSettings["404ContentPageId"])) };
 
             model.TheTemplate = ContentLoader.GetContentTemplate(model.ThePage.Template);
             model.PageData = ContentUtils.GetFormattedPageContentAndScripts(model.ThePage.HTMLContent);
 
             ViewBag.IsPage = true;
             ViewBag.PageId = model.ThePage.ContentPageId;
-            ViewBag.IsPublished = model.ThePage.IsActive;
+            return ViewBag.IsPublished = model.ThePage.IsActive;
             ViewBag.Title = model.ThePage.Title;
             ViewBag.Index = "noindex";
             ViewBag.Follow = "nofollow";

--- a/DirigoEdge/Controllers/BlogController.cs
+++ b/DirigoEdge/Controllers/BlogController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Configuration;
 using System.Linq;
 using System.ServiceModel.Syndication;
 using System.Web.Mvc;
@@ -89,7 +90,7 @@ namespace DirigoEdge.Controllers
         {
             get
             {
-                var model = new ContentViewViewModel { ThePage = ContentLoader.GetDetailsByTitle("404") };
+                var model = new ContentViewViewModel { ThePage = ContentLoader.GetDetailsById(Convert.ToInt16(ConfigurationManager.AppSettings["404ContentPageId"])) };
 
                 model.TheTemplate = ContentLoader.GetContentTemplate(model.ThePage.Template);
                 model.PageData = ContentUtils.GetFormattedPageContentAndScripts(model.ThePage.HTMLContent);

--- a/DirigoEdge/Controllers/HomeController.cs
+++ b/DirigoEdge/Controllers/HomeController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Net;
 using System.Net.Mail;
 using System.Text;
@@ -18,7 +19,7 @@ namespace DirigoEdge.Controllers
 	{
 		public ActionResult Index()
 		{
-		    var model = new ContentViewViewModel {ThePage = ContentLoader.GetDetailsByTitle("home")};
+		    var model = new ContentViewViewModel {ThePage = ContentLoader.GetDetailsByPermalink("home")};
 
 		    if (model.ThePage != null)
             {
@@ -41,7 +42,7 @@ namespace DirigoEdge.Controllers
                 return View(model.TheTemplate.ViewLocation, model);
             }
 
-            model = new ContentViewViewModel { ThePage = ContentLoader.GetDetailsByTitle("404") };
+            model = new ContentViewViewModel { ThePage = ContentLoader.GetDetailsById(Convert.ToInt16(ConfigurationManager.AppSettings["404ContentPageId"])) };
 
             model.TheTemplate = ContentLoader.GetContentTemplate(model.ThePage.Template);
             model.PageData = ContentUtils.GetFormattedPageContentAndScripts(model.ThePage.HTMLContent);

--- a/DirigoEdge/DirigoEdgeWeb.csproj
+++ b/DirigoEdge/DirigoEdgeWeb.csproj
@@ -62,8 +62,8 @@
     <Reference Include="AutoMapper.Net4">
       <HintPath>..\packages\AutoMapper.3.3.1\lib\net40\AutoMapper.Net4.dll</HintPath>
     </Reference>
-    <Reference Include="DirigoEdgeCore, Version=1.8.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DirigoEdgeCore.1.8.1.0\lib\net45\DirigoEdgeCore.dll</HintPath>
+    <Reference Include="DirigoEdgeCore, Version=1.8.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DirigoEdgeCore.1.8.2.0\lib\net45\DirigoEdgeCore.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">

--- a/DirigoEdge/Web.config
+++ b/DirigoEdge/Web.config
@@ -33,6 +33,7 @@
     <add key="TwitterOAuthUrl" value=""/>
     <add key="ExcludeSchemas" value="1"/>
     <add key="ExcludeSchemasForNavigation" value="1"/>
+    <add key="404ContentPageId" value="1"/>
   </appSettings>
   <system.web>
    <customErrors mode="RemoteOnly">

--- a/DirigoEdge/packages.config
+++ b/DirigoEdge/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="AutoMapper" version="3.3.1" targetFramework="net45" />
   <package id="CodeFirstMembershipProviderSharp" version="1.0.0" targetFramework="net45" />
-  <package id="DirigoEdgeCore" version="1.8.1.0" targetFramework="net45" />
+  <package id="DirigoEdgeCore" version="1.8.2.0" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.2" targetFramework="net45" />
   <package id="ImageResizer" version="3.4.3" targetFramework="net45" />
   <package id="ImageResizer.Plugins.PrettyGifs" version="3.4.3" targetFramework="net45" />

--- a/DirigoEdge/packages.config
+++ b/DirigoEdge/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="AutoMapper" version="3.3.1" targetFramework="net45" />
   <package id="CodeFirstMembershipProviderSharp" version="1.0.0" targetFramework="net45" />
-  <package id="DirigoEdgeCore" version="1.8.2.0" targetFramework="net45" />
+  <package id="DirigoEdgeCore" version="1.9.0.0" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.2" targetFramework="net45" />
   <package id="ImageResizer" version="3.4.3" targetFramework="net45" />
   <package id="ImageResizer.Plugins.PrettyGifs" version="3.4.3" targetFramework="net45" />


### PR DESCRIPTION
**Requires https://github.com/dirigodev/DirigoEdgeCore/pull/50**

This diff is mostly useless, THANKS CRLF.

Naming in `ContentController` was terrible. Also removed DisplayName check, which was allowing pages to exist at 2 different URLs.

404 is now referenced by an ID in the web.config.