### PR TITLE
Don't stringify GET data in AJAX service

### DIFF
--- a/DirigoEdge/Scripts/Edge/ajax-service.js
+++ b/DirigoEdge/Scripts/Edge/ajax-service.js
@@ -30,7 +30,7 @@ EDGE.prototype.ajaxGet = function (data, url, success, error) {
     return $.ajax({
         url: url,
         type: 'GET',
-        data: data ? JSON.stringify(data, null, 2) : null,
+        data: data,
         contentType: 'application/json; charset=utf-8',
         success: success,
         error: error


### PR DESCRIPTION
If we stringify the data we end up with something like `/?{%20%20id%20:%2023%20%20}`. What we want is something like `/?id=23`