### PR TITLE
Adding check for existing page with current page set to parent

### DIFF
--- a/DirigoEdge/Areas/Admin/Controllers/NavigationController.cs
+++ b/DirigoEdge/Areas/Admin/Controllers/NavigationController.cs
@@ -160,12 +160,11 @@ namespace DirigoEdge.Areas.Admin.Controllers
                             result.Data = new
                             {
                                 success = false,
-                                message = "Navigation not saved. Navigation item <strong>" +
-                                    navItem.Name + "</strong> cannot use <strong>" + page.Title + "</strong> as its content page." +
-                                     " The content page <strong>" + page.Title + "</strong> has its parent set to this navigation item. " +
-                                    "Please change the page's parent setting " +
-                                     "<a target=\"_blank\" href=\"/admin/pages/editcontent/" + page.ContentPageId + "/\">here</a>, " +
-                                     "or set the navigation item's page to something different."
+                                message = "Navigation not saved.",
+                                name = navItem.Name,
+                                title = page.Title,
+                                id = page.ContentPageId
+
                             };
                             return result;
                         }

--- a/DirigoEdge/Areas/Admin/Controllers/NavigationController.cs
+++ b/DirigoEdge/Areas/Admin/Controllers/NavigationController.cs
@@ -137,6 +137,9 @@ namespace DirigoEdge.Areas.Admin.Controllers
             var nav = Context.Navigations.FirstOrDefault(x => x.NavigationId == navigationId);
             nav.Name = name;
 
+            // get all content pages to be able to search
+            var allPages = Context.ContentPages.Where(x => x.IsActive == true).ToList();
+
             // Make sure Nav Items aren't null
             items = items ?? new List<NavigationItem>();
 
@@ -146,6 +149,27 @@ namespace DirigoEdge.Areas.Admin.Controllers
                 var item = Context.NavigationItems.FirstOrDefault(x => x.NavigationItemId == navItem.NavigationItemId);
                 if (item != null)
                 {
+                    var contentPageId = navItem.ContentPageId;
+                    if (navItem.UsesContentPage)
+                    {
+                        // make sure the content page it uses doesn't have it set as a parent
+                        var page = allPages.FirstOrDefault(x => x.ContentPageId == contentPageId);
+                        if (page != null && page.ParentNavigationItemId == navItem.NavigationItemId)
+                        {
+                            // this nav item is trying to use a page that has it set as the parent, infinite loop
+                            result.Data = new
+                            {
+                                success = false,
+                                message = "Navigation not saved. Navigation item <strong>" +
+                                    navItem.Name + "</strong> cannot use <strong>" + page.Title + "</strong> as its content page." +
+                                     " The content page <strong>" + page.Title + "</strong> has its parent set to this navigation item. " +
+                                    "Please change the page's parent setting " +
+                                     "<a target=\"_blank\" href=\"/admin/pages/editcontent/" + page.ContentPageId + "/\">here</a>, " +
+                                     "or set the navigation item's page to something different."
+                            };
+                            return result;
+                        }
+                    }
                     item.Name = navItem.Name;
                     item.Href = navItem.Href;
                     item.Order = navItem.Order;
@@ -163,9 +187,9 @@ namespace DirigoEdge.Areas.Admin.Controllers
             if (success > 0)
             {
                 // Clear the cache of the nav on save
-                CachedObjects.GetCacheNavigationList(0, true);      
+                CachedObjects.GetCacheNavigationList(0, true);
 
-                BookmarkUtil.DeleteBookmarkForUrl("/admin/navigation/editnav/" + navigationId +"/");
+                BookmarkUtil.DeleteBookmarkForUrl("/admin/navigation/editnav/" + navigationId + "/");
 
                 result.Data = new
                 {

--- a/DirigoEdge/Areas/Admin/Scripts/navBuilder.js
+++ b/DirigoEdge/Areas/Admin/Scripts/navBuilder.js
@@ -116,6 +116,8 @@ navBuilder_class.prototype.initSaveEvent = function () {
 
         var $container = $("#BuildList");
         common.showAjaxLoader($container);
+        var $err = $('.navigation-error');
+        $err.addClass('hide').html('');
 
         var ParentNavId = $("#BuildList").attr("data-id");
 
@@ -183,10 +185,17 @@ navBuilder_class.prototype.initSaveEvent = function () {
             data: JSON.stringify(data, null, 2),
             success: function (data) {
                 common.hideAjaxLoader($container);
-                var noty_id = noty({ text: 'Navigation set saved successfully.', type: 'success', timeout: 1200 });
+                if (data.success) {
+                    noty({ text: 'Navigation saved successfully!', type: 'success', timeout: 1200 });
+                    $err.addClass('hide').html('');
+                } else {
+                    noty({ text: 'Navigation not saved.', type: 'error', timeout: 3000 });
+                    $err.removeClass('hide').html(data.message);
+                }
             },
             error: function (data) {
-                var noty_id = noty({ text: 'There was an error processing your request.', type: 'error', timeout: 3000 });
+                noty({ text: 'There was an error processing your request.', type: 'error', timeout: 3000 });
+                $err.addClass('hide').html('');
             }
         });
 

--- a/DirigoEdge/Areas/Admin/Scripts/navBuilder.js
+++ b/DirigoEdge/Areas/Admin/Scripts/navBuilder.js
@@ -189,8 +189,13 @@ navBuilder_class.prototype.initSaveEvent = function () {
                     noty({ text: 'Navigation saved successfully!', type: 'success', timeout: 1200 });
                     $err.addClass('hide').html('');
                 } else {
-                    noty({ text: 'Navigation not saved.', type: 'error', timeout: 3000 });
-                    $err.removeClass('hide').html(data.message);
+                    noty({ text: data.message, type: 'error', timeout: 3000 });
+                    $err.removeClass('hide').html('Navigation not saved. Navigation item <strong>' +
+                            data.name + '</strong> cannot use <strong>' + data.title + '</strong> as its content page.' +
+                            ' The content page <strong>' + data.title + '</strong> has its parent set to this navigation item. ' +
+                            'Please change the page\'s parent setting ' +
+                            '<a target="_blank" href="/admin/pages/editcontent' + data.id + '">here</a>, ' +
+                            'or set the navigation item\'s page to something different.');
                 }
             },
             error: function (data) {

--- a/DirigoEdge/Areas/Admin/Views/Navigation/EditNav.cshtml
+++ b/DirigoEdge/Areas/Admin/Views/Navigation/EditNav.cshtml
@@ -17,6 +17,7 @@
         <div class="navSaveContainer">
             <a class="btn btn-primary" id="AddNavItem" href="#">Add Item +</a>
             <a class="btn btn-primary" id="SaveNavigation" href="#">Save Navigation</a>
+            <div class="alert alert-danger navigation-error hide"></div>
         </div>
 
         <ol id="BuildList" class="topLevelNav" data-id="@Model.TheNav.NavigationId">

--- a/SmokeTests/SmokeTests.csproj
+++ b/SmokeTests/SmokeTests.csproj
@@ -47,8 +47,8 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Drawing" />
-    <Reference Include="WebDriver, Version=2.47.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.2.47.0\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=2.48.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.2.48.0\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -74,7 +74,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\packages\WebDriver.ChromeDriver.win32.2.16.0.0\content\chromedriver.exe">
+    <Content Include="..\packages\Selenium.WebDriver.ChromeDriver.2.20.0.0\driver\chromedriver.exe">
       <Link>chromedriver.exe</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/SmokeTests/packages.config
+++ b/SmokeTests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
-  <package id="Selenium.WebDriver" version="2.47.0" targetFramework="net452" />
+  <package id="Selenium.WebDriver" version="2.48.0" targetFramework="net452" />
+  <package id="Selenium.WebDriver.ChromeDriver" version="2.20.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
When we set the content page on a navigation item (in the navbuilder), we now check to see if this content page we want to use already has this navigation item set as it's parent. If so, it is the cause of one of our navigation loops.