### PR TITLE
updating checkpermalink to not check when events

### DIFF
--- a/DirigoEdge/Areas/Admin/Controllers/PagesController.cs
+++ b/DirigoEdge/Areas/Admin/Controllers/PagesController.cs
@@ -447,6 +447,13 @@ namespace DirigoEdge.Areas.Admin.Controllers
                     message = ""
                 }
             };
+
+            // if id == 0, this is not a content page, we are not verifying permalink, should be from event call, just return
+            if (id < 1)
+            {
+                return result;
+            }
+
             var contentUtility = new ContentUtils();
 
             // check to see if permalink exists

--- a/DirigoEdge/Areas/Admin/Scripts/contentAdmin.js
+++ b/DirigoEdge/Areas/Admin/Scripts/contentAdmin.js
@@ -15,6 +15,9 @@ content_class.prototype.initPageEvents = function () {
         this.initWordWrapEvents();
         this.initContentImageUploadEvents();
         this.initModuleUploadEvents();
+
+        // permalink
+        this.initPermaLinkEvents();
     }
 
     if ($("div.manageContent").length > 0) {
@@ -36,9 +39,6 @@ content_class.prototype.initPageEvents = function () {
 
     // Generate Url Structure
     this.initParentCategoryEvents();
-
-    // permalink
-    this.initPermaLinkEvents();
 };
 
 content_class.prototype.initWordWrapEvents = function () {


### PR DESCRIPTION
We aren't concerned with permalink duplicates. Return when id is 0.