### PR TITLE
Disable title attribute on CKEditor instances

### DIFF
--- a/DirigoEdge/Scripts/ckeditor/config.js
+++ b/DirigoEdge/Scripts/ckeditor/config.js
@@ -4,33 +4,33 @@
  */
 
 CKEDITOR.editorConfig = function( config ) {
-	// Define changes to default configuration here.
-	// For the complete reference:
-	// http://docs.ckeditor.com/#!/api/CKEDITOR.config
+    // Define changes to default configuration here.
+    // For the complete reference:
+    // http://docs.ckeditor.com/#!/api/CKEDITOR.config
 
-	// The toolbar groups arrangement, optimized for two toolbar rows.
-	config.toolbarGroups = [
-		{ name: 'clipboard',   groups: [ 'clipboard', 'undo' ] },
-		{ name: 'links' },
-		{ name: 'insert' },
-		{ name: 'tools' },
-		{ name: 'document',	   groups: [ 'mode', 'document', 'doctools' ] },
-		{ name: 'others' },
-		'/',
-		{ name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ] },
-		{ name: 'paragraph',   groups: [ 'list', 'indent', 'blocks' ] },
-		{ name: 'styles' },
-		{ name: 'about' }
-	];
+    // The toolbar groups arrangement, optimized for two toolbar rows.
+    config.toolbarGroups = [
+        { name: 'clipboard',   groups: [ 'clipboard', 'undo' ] },
+        { name: 'links' },
+        { name: 'insert' },
+        { name: 'tools' },
+        { name: 'document',	   groups: [ 'mode', 'document', 'doctools' ] },
+        { name: 'others' },
+        '/',
+        { name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ] },
+        { name: 'paragraph',   groups: [ 'list', 'indent', 'blocks' ] },
+        { name: 'styles' },
+        { name: 'about' }
+    ];
 
-	// Remove some buttons, provided by the standard plugins, which we don't
-	// need to have in the standard toolbar.
-	config.removeButtons = 'Underline,Subscript,Superscript,Image,Flash,Smiley,PageBreak,Iframe,ShowBlocks,Save,NewPage,Preview,Print,Templates,CreateDiv,Font,FontSize';
-	config.removeDialogTabs = 'link:advanced';
-	config.removePlugins = 'magicline';
-	config.extraPlugins = 'codemirror,insertimage';
-	config.disableNativeSpellChecker = false;
-	config.allowedContent = true;
+    // Remove some buttons, provided by the standard plugins, which we don't
+    // need to have in the standard toolbar.
+    config.removeButtons = 'Underline,Subscript,Superscript,Image,Flash,Smiley,PageBreak,Iframe,ShowBlocks,Save,NewPage,Preview,Print,Templates,CreateDiv,Font,FontSize';
+    config.removeDialogTabs = 'link:advanced';
+    config.removePlugins = 'magicline';
+    config.extraPlugins = 'codemirror,insertimage';
+    config.disableNativeSpellChecker = false;
+    config.allowedContent = true;
 
     config.title = false;
 };

--- a/DirigoEdge/Scripts/ckeditor/config.js
+++ b/DirigoEdge/Scripts/ckeditor/config.js
@@ -30,5 +30,7 @@ CKEDITOR.editorConfig = function( config ) {
 	config.removePlugins = 'magicline';
 	config.extraPlugins = 'codemirror,insertimage';
 	config.disableNativeSpellChecker = false;
-    config.allowedContent = true;
+	config.allowedContent = true;
+
+    config.title = false;
 };


### PR DESCRIPTION
CKEditor currently adds `title="Rich Text Editor, rt_0"` to all the rich text area DIVs, which results in a tooltip when you hover over content.