### PR TITLE
Fix redirect leading slash enforcement for external destinations

### DIFF
--- a/DirigoEdge/Areas/Admin/Scripts/redirectAdmin.js
+++ b/DirigoEdge/Areas/Admin/Scripts/redirectAdmin.js
@@ -95,11 +95,22 @@ redirect_class.prototype.initRedirectEvents = function () {
         });
     });
 
-    $('#SourceInput, #DestinationInput, #EditSourceInput, #EditDestinationInput').on('keyup', function (e) {
-        var $val = $(this);
+    $('#SourceInput, #EditSourceInput').on('keyup', function (e) {
+        var $input = $(this);
+        var source = $input.val();
 
-        if ($val.val().indexOf("/") !== 0) {
-            $val.val('/' + $val.val());
+        if (source.indexOf("/") !== 0) {
+            $input.val('/' + source);
+        }
+    });
+
+    $('#DestinationInput, #EditDestinationInput').on('blur', function (e) {
+        var $input = $(this);
+        var destination = $input.val();
+
+        // Enforce leading slash unless destination is external
+        if (!destination.match(/^http/) && destination.indexOf("/") !== 0) {
+            $input.val('/' + destination);
         }
     });
 

--- a/DirigoEdge/Areas/Admin/Scripts/redirectAdmin.js
+++ b/DirigoEdge/Areas/Admin/Scripts/redirectAdmin.js
@@ -109,7 +109,7 @@ redirect_class.prototype.initRedirectEvents = function () {
         var destination = $input.val();
 
         // Enforce leading slash unless destination is external
-        if (!destination.match(/^http/) && destination.indexOf("/") !== 0) {
+        if (!destination.match(/^https?:\/\//) && destination.indexOf("/") !== 0) {
             $input.val('/' + destination);
         }
     });

--- a/DirigoEdge/Areas/Admin/Views/Redirect/Redirects.cshtml
+++ b/DirigoEdge/Areas/Admin/Views/Redirect/Redirects.cshtml
@@ -197,9 +197,9 @@
 {
     <small>
         When enabled <code>/source-path/</code> will match:<br />
-        <code>/destination-path/</code><br />
-        <code>/destination-path/new-page</code><br />
-        <code>/destination-path/new-page/two</code><br />
+        <code>/source-path/</code><br />
+        <code>/source-path/new-page</code><br />
+        <code>/source-path/new-page/two</code><br />
         etc.
     </small>
 }


### PR DESCRIPTION
Currently in the destination path `http://google.com` is changed to `/http://google.com`. This removes the leading slash enforcement for any path starting with `http://` or `https://`.

Also fixes the tooltip issue from #118 